### PR TITLE
Use SSLv3 to make requests to ssl endpoints

### DIFF
--- a/lib/requester.rb
+++ b/lib/requester.rb
@@ -4,7 +4,7 @@ module Requester
   extend HTTParty
 
   def get(uri_string)
-    response = HTTParty.get(uri_string, timeout: 5)
+    response = HTTParty.get(uri_string, timeout: 5, ssl_version: "SSLv3")
     if response.success?
       JSON.parse response.body
     else


### PR DESCRIPTION
This should solve #8, although I can't explain exactly why. On a fresh deploy to Heroku I was seeing the following error prior to making this change:

``` shell
[engine-light (master)]$ heroku run console
Running `console` attached to terminal... up, run.6996
Loading production environment (Rails 4.0.0)
irb(main):001:0> requester = Class.new{include Requester}.new
=> #<#<Class:0x007fa37a7530d0>:0x007fa37a752ec8>
irb(main):002:0> requester.get("https://jekit.codeforamerica.org/.well-known/status")
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: (null)
    from /app/vendor/ruby-2.0.0/lib/ruby/2.0.0/net/http.rb:918:in `connect'
    from /app/vendor/ruby-2.0.0/lib/ruby/2.0.0/net/http.rb:918:in `block in connect'
    from /app/vendor/ruby-2.0.0/lib/ruby/2.0.0/timeout.rb:66:in `timeout'
    from /app/vendor/ruby-2.0.0/lib/ruby/2.0.0/net/http.rb:918:in `connect'
    from /app/vendor/ruby-2.0.0/lib/ruby/2.0.0/net/http.rb:862:in `do_start'
    from /app/vendor/ruby-2.0.0/lib/ruby/2.0.0/net/http.rb:851:in `start'
    from /app/vendor/ruby-2.0.0/lib/ruby/2.0.0/net/http.rb:1367:in `request'
    from /app/vendor/bundle/ruby/2.0.0/gems/httparty-0.11.0/lib/httparty/request.rb:92:in `perform'
    from /app/vendor/bundle/ruby/2.0.0/gems/httparty-0.11.0/lib/httparty.rb:461:in `perform_request'
    from /app/vendor/bundle/ruby/2.0.0/gems/httparty-0.11.0/lib/httparty.rb:398:in `get'
    from /app/vendor/bundle/ruby/2.0.0/gems/httparty-0.11.0/lib/httparty.rb:493:in `get'
    from /app/lib/requester.rb:7:in `get'
    from (irb):2
    from /app/vendor/bundle/ruby/2.0.0/gems/railties-4.0.0/lib/rails/commands/console.rb:90:in `start'
    from /app/vendor/bundle/ruby/2.0.0/gems/railties-4.0.0/lib/rails/commands/console.rb:9:in `start'
    from /app/vendor/bundle/ruby/2.0.0/gems/railties-4.0.0/lib/rails/commands.rb:64:in `<top (required)>'
    from bin/rails:4:in `require'
    from bin/rails:4:in `<main>'irb(main):003:0>
```
