### PR TITLE
add node-engine-light to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Uses Mozilla Persona to handle login. The app will only allow users with CfA ema
 
 ### Links to existing status endpoint implementations
 
+#### Node.js
+- [node-engine-light](https://github.com/jeremiak/node-engine-light) (middleware module)
+
 #### Python
 - [RecordTrac](https://github.com/codeforamerica/public-records/blob/master/public_records_portal/template_renderers.py) (search for "well_known_status")
 - [BizFriendly API](https://github.com/codeforamerica/bizfriendly-api/blob/master/bizfriendly/routes.py) (search for "well-known")


### PR DESCRIPTION
when adding a new platform to the list, I simply went with lexicographic sort order.
