### PR TITLE
Fix RecordTrac implementation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Uses Mozilla Persona to handle login. The app will only allow users with CfA ema
 ### Links to existing status endpoint implementations
 
 #### Python
-- [RecordTrac](https://github.com/codeforamerica/public-records/blob/master/public_records_portal/template_renderers.py) (search for "well_known_status")
+- [RecordTrac](https://github.com/codeforamerica/recordtrac/blob/master/public_records_portal/views.py) (search for "well_known_status")
 - [BizFriendly API](https://github.com/codeforamerica/bizfriendly-api/blob/master/bizfriendly/routes.py) (search for "well-known")
 
 #### Ruby


### PR DESCRIPTION
Looks like the file that the implementation was in changed for RecordTrac — this PR updates the link to the new file location in that repo